### PR TITLE
Added RISCV and Linux support.

### DIFF
--- a/ext/hatstone/extconf.rb
+++ b/ext/hatstone/extconf.rb
@@ -4,18 +4,35 @@ require 'mkmf'
 
 ldflags = cppflags = nil
 
-begin
-  brew_prefix = `brew --prefix hidapi`.chomp
-  ldflags   = "#{brew_prefix}/lib"
-  cppflags  = "#{brew_prefix}/include"
-  pkg_conf  = "#{brew_prefix}/lib/pkgconfig"
+if RUBY_PLATFORM =~ /darwin/
+  # macOS specific configuration using Homebrew
+  begin
+    brew_prefix = `brew --prefix hidapi`.chomp
+    ldflags   = "#{brew_prefix}/lib"
+    cppflags  = "#{brew_prefix}/include"
+    pkg_conf  = "#{brew_prefix}/lib/pkgconfig"
 
-  ENV["PKG_CONFIG_PATH"] = pkg_conf
-rescue
+    ENV["PKG_CONFIG_PATH"] = pkg_conf
+  rescue
+  end
+else
+  # Linux systems typically use pkg-config
+  [
+    "/usr/lib/pkgconfig",
+    "/usr/local/lib/pkgconfig",
+    "/usr/lib/`uname -m`-linux-gnu/pkgconfig"
+  ].each do |path|
+    if File.directory?(path)
+      ENV["PKG_CONFIG_PATH"] = [ENV["PKG_CONFIG_PATH"], path].compact.join(":")
+    end
+  end
 end
 
-pkg_config "capstone"
-dir_config "capstone", cppflags, ldflags
+# Try to find capstone using pkg-config first
+unless pkg_config("capstone")
+  # Fallback to manual configuration
+  dir_config("capstone", cppflags, ldflags)
+end
 
 raise "Install capstone!" unless have_header "capstone.h"
 raise "Install capstone!" unless have_library "capstone"

--- a/ext/hatstone/hatstone_enums.inc
+++ b/ext/hatstone/hatstone_enums.inc
@@ -92,3 +92,13 @@ rb_define_const(klass, "ERR_SKIPDATA", INT2NUM(CS_ERR_SKIPDATA));
 rb_define_const(klass, "ERR_X86_ATT", INT2NUM(CS_ERR_X86_ATT));
 rb_define_const(klass, "ERR_X86_INTEL", INT2NUM(CS_ERR_X86_INTEL));
 rb_define_const(klass, "ERR_X86_MASM", INT2NUM(CS_ERR_X86_MASM));
+
+#ifdef CS_API_MAJOR
+#if CS_API_MAJOR >= 5
+rb_define_const(klass, "ARCH_RISCV", INT2NUM(CS_ARCH_RISCV));
+rb_define_const(klass, "MODE_RISCV32", INT2NUM(CS_MODE_RISCV32));
+rb_define_const(klass, "MODE_RISCV64", INT2NUM(CS_MODE_RISCV64));
+rb_define_const(klass, "MODE_RISCVC", INT2NUM(CS_MODE_RISCVC));
+#endif
+#endif
+

--- a/test/hatstone_arm64_test.rb
+++ b/test/hatstone_arm64_test.rb
@@ -1,6 +1,6 @@
 require "helper"
 
-class HatstoneTest < Hatstone::Test
+class HatstoneArm64Test < Hatstone::Test
   def test_disasm
     hs = Hatstone.new(Hatstone::ARCH_ARM64, Hatstone::MODE_ARM)
 
@@ -11,7 +11,8 @@ class HatstoneTest < Hatstone::Test
     ].pack("L<L<")
 
     disassembled = hs.disasm(insns, 0x0)
-    assert_equal "movz", disassembled[0].mnemonic
+    
+    assert_equal "mov", disassembled[0].mnemonic
     assert_equal "ret", disassembled[1].mnemonic
   end
 
@@ -29,3 +30,4 @@ class HatstoneTest < Hatstone::Test
     insn
   end
 end
+

--- a/test/hatstone_riscv64_test.rb
+++ b/test/hatstone_riscv64_test.rb
@@ -1,0 +1,44 @@
+require "helper"
+
+class HatstoneRiscv64Test < Hatstone::Test
+  def test_disasm
+
+    insns = [
+      lui(17, 64),  # lui a7, 64 
+      lui(10, 1),   # lui a0, 1 
+      auipc(0, 0), # auipc a0,0x0 
+      addi(0, 36), # addi a0,a0,36
+    ].pack("L<*")
+
+    hs = Hatstone.new(Hatstone::ARCH_RISCV, Hatstone::MODE_RISCV64)
+
+    disassembled = hs.disasm(insns, 0x0)
+
+    assert_equal "lui", disassembled[0].mnemonic
+    assert_equal "lui", disassembled[1].mnemonic
+    assert_equal "auipc", disassembled[2].mnemonic
+    assert_equal "addi", disassembled[3].mnemonic
+  end
+
+  def lui reg, imm
+    insn = 0b00000000000000000000_00000_0110111  # lui base
+    insn |= (reg << 7)  # Set destination register 
+    insn |= (imm & 0xFFFFF) << 12  # Set 20-bit immediate
+    insn
+  end
+
+  def auipc reg, imm
+    insn = 0b00000000000000000000_00000_0010111  # auipc base
+    insn |= (reg << 7)  # Set destination register
+    insn |= (imm & 0xFFFFF) << 12  # Set 20-bit immediate
+    insn
+  end
+      
+  def addi reg, imm
+    insn = 0b00000000000000000000_00000_0010011  # addi base
+    insn |= (reg << 7)  # Set destination register
+    insn |= (reg << 15)  # Set source register
+    insn |= (imm & 0xFFF) << 20  # Set 12-bit immediate
+    insn
+  end
+end


### PR DESCRIPTION
Hey there @tenderlove !

Recently I have been playing with RISCV64 assembly and I am also a Rubyst. Soo, I found this little wrapper and noticed it had support only for macOS on ARM64  So I added support for Linux and/or RISCV 😄.

## Some details

- As a I mentioned, made the gem compatible with Linux, was only building for macOS + brew.
- Added support for disassembling RISC-V (conditionally, only in libcapstone v5 or greater).
- Added some tests for RISCV, then split them by arch.
- Updated docs, examples.

Small video of the tests running on a real RISC-V machine:

[Screencast_20241105_154929.webm](https://github.com/user-attachments/assets/c57ad76a-7d51-4ef8-a4de-6592b960e3ba)

I think these changes should make the gem build on non RISC-V linux machines. Testing that now.

🏃🏼‍♂️ 